### PR TITLE
Adds new routes for users to request to join event, approve users, and change status

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -5,6 +5,8 @@
 - /locations
 - /events 
 - /events/:id
+- /events/:id/join
+- /events/:id/approve
 - /users/login
 - /users/signup
 - /users/:id
@@ -149,6 +151,30 @@ Modifies an event
 ```javascript
 tbd
 ```
+
+## /events/:id/join
+###POST request
+Creates new request for a user to join an event
+
+#### Response format
+Returns a 200 if the user was able to request ot join
+
+## /events/:id/approve
+###PUT request
+Allows hosts to approve or reject users that requested to join their event
+
+### Required request body
+- user: userid 
+- approved: true/false
+
+#### Example request
+```javascript
+{ user: 3, 
+  approved: true }
+```
+
+#### Response format
+Returns a 200 if the approval/rejection went successfully, 403 if the user is not the host, and 400 if there's a missing field from the body.
 
 ## /users/login
 Logs a user in

--- a/server/README.md
+++ b/server/README.md
@@ -7,6 +7,7 @@
 - /events/:id
 - /events/:id/join
 - /events/:id/approve
+- /events/:id/status
 - /users/login
 - /users/signup
 - /users/:id
@@ -175,6 +176,21 @@ Allows hosts to approve or reject users that requested to join their event
 
 #### Response format
 Returns a 200 if the approval/rejection went successfully, 403 if the user is not the host, and 400 if there's a missing field from the body.
+
+## /events/:id/status
+###PUT request
+Updates a user's status message for a certain event
+
+### Required request body
+- status: string
+
+#### Example request
+```javascript
+{ status: 'walking over'}
+```
+
+#### Response format
+Returns a 200 if the update went successfully, 400 if the user is not a participant in this event.
 
 ## /users/login
 Logs a user in

--- a/server/controllers/events.js
+++ b/server/controllers/events.js
@@ -127,6 +127,28 @@ module.exports = {
     });
   },
 
+  joinEvent: function(req, res) {
+    var models = req.app.get('models');
+    var UserEvent = models.UserEvent;
+
+    var currentUser = req.userId;
+    var newUserEvent = {
+      EventId: req.params.eventId,
+      UserId: currentUser,
+      userConfirmed: false,
+      arrivalStatus: 'Pending',
+      cohost: false
+    };  
+
+    UserEvent.sync().then(function() {
+      return UserEvent.create(newUserEvent);
+    }).then(function(userEvent) {
+      utils.sendResponse(res, 200, userEvent);
+    }).catch(function(err) {
+      utils.sendResponse(res, 500, 'Error: ', err);
+    });
+  },
+
   getEventHistoryByUser: function (req, res) {
     var models = req.app.get('models');
     var User = models.User;

--- a/server/controllers/events.js
+++ b/server/controllers/events.js
@@ -41,6 +41,7 @@ module.exports = {
   createEvent: function(req, res){
     var models = req.app.get('models');
     var Event = models.Event;
+    var UserEvent = models.UserEvent;
 
     /* The newEvent object contains a number of properties -- some obtained
        from the body of the request and some defaults. This object is used
@@ -60,6 +61,17 @@ module.exports = {
         return Event.create(newEvent);
       }).then (function (newEvent) {
         utils.sendResponse(res, 201, newEvent);
+
+        var newUserEvent = {
+          EventId: newEvent.id,
+          UserId: req.userId,
+          cohost: true
+        };  
+
+        UserEvent.sync().then(function() {
+          return UserEvent.create(newUserEvent);
+        });
+
       }).catch(function (err) {
         console.log('Error: ', err);
       });

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -7,6 +7,7 @@ module.exports = function(app){
 
   app.get('/events/:eventId', eventController.getEvent);
   app.put('/events/:eventId', eventController.updateEvent);
+  app.post('/events/:eventId/join', eventController.joinEvent);
 
   app.get('/users/:userId/history', eventController.getEventHistoryByUser);
 };

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -8,7 +8,7 @@ module.exports = function(app){
   app.get('/events/:eventId', eventController.getEvent);
   app.put('/events/:eventId', eventController.updateEvent);
   app.post('/events/:eventId/join', eventController.joinEvent);
-  app.post('/events/:eventId/approve', eventController.approveUser);
+  app.put('/events/:eventId/approve', eventController.approveUser);
 
   app.get('/users/:userId/history', eventController.getEventHistoryByUser);
 };

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -9,6 +9,7 @@ module.exports = function(app){
   app.put('/events/:eventId', eventController.updateEvent);
   app.post('/events/:eventId/join', eventController.joinEvent);
   app.put('/events/:eventId/approve', eventController.approveUser);
+  app.put('/events/:eventId/status', eventController.changeStatus);
 
   app.get('/users/:userId/history', eventController.getEventHistoryByUser);
 };

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -8,6 +8,7 @@ module.exports = function(app){
   app.get('/events/:eventId', eventController.getEvent);
   app.put('/events/:eventId', eventController.updateEvent);
   app.post('/events/:eventId/join', eventController.joinEvent);
+  app.post('/events/:eventId/approve', eventController.approveUser);
 
   app.get('/users/:userId/history', eventController.getEventHistoryByUser);
 };

--- a/test/eventsTests.js
+++ b/test/eventsTests.js
@@ -151,4 +151,18 @@ describe('Events routes: ', function() {
     });
   });
 
+  describe('should allow users to join events', function() {
+    it('should allow users to request to join events', function(done) {
+      utils.logIn(function(result, accessToken) {
+        request
+          .post('/events/1/join?accessToken='+accessToken)
+          .end(function(err, actualResponse) {
+            assert.equal(actualResponse.body.UserId, 3);
+            done();
+          });
+      },2);
+    });
+
+  });
+
 });

--- a/test/eventsTests.js
+++ b/test/eventsTests.js
@@ -167,7 +167,7 @@ describe('Events routes: ', function() {
       utils.logIn(function(result, accessToken) {
         var requestbody = {user: 3, approved: true};
         request
-          .post('/events/1/approve?accessToken='+accessToken)
+          .put('/events/1/approve?accessToken='+accessToken)
           .send(requestbody)
           .expect(200, done);
       }, 1);
@@ -177,7 +177,7 @@ describe('Events routes: ', function() {
       utils.logIn(function(result, accessToken) {
         var requestbody = {user: 3, approved: true};
         request
-          .post('/events/1/approve?accessToken='+accessToken)
+          .put('/events/1/approve?accessToken='+accessToken)
           .send(requestbody)
           .expect(403, done);
       }, 0);

--- a/test/eventsTests.js
+++ b/test/eventsTests.js
@@ -160,7 +160,27 @@ describe('Events routes: ', function() {
             assert.equal(actualResponse.body.UserId, 3);
             done();
           });
-      },2);
+      }, 2);
+    });
+
+    it('should allow hosts to approve users of their events', function(done) {
+      utils.logIn(function(result, accessToken) {
+        var requestbody = {user: 3, approved: true};
+        request
+          .post('/events/1/approve?accessToken='+accessToken)
+          .send(requestbody)
+          .expect(200, done);
+      }, 1);
+    });
+
+    it('should not allow non-hosts to approve users', function(done) {
+      utils.logIn(function(result, accessToken) {
+        var requestbody = {user: 3, approved: true};
+        request
+          .post('/events/1/approve?accessToken='+accessToken)
+          .send(requestbody)
+          .expect(403, done);
+      }, 0);
     });
 
   });

--- a/test/eventsTests.js
+++ b/test/eventsTests.js
@@ -183,6 +183,26 @@ describe('Events routes: ', function() {
       }, 0);
     });
 
+    it('should allow users to change their status messages', function(done) {
+      utils.logIn(function(result, accessToken) {
+        var requestbody = {status: 'walking over'};
+        request
+          .put('/events/1/status?accessToken='+accessToken)
+          .send(requestbody)
+          .expect(200, done);
+      }, 1);
+    });
+
+    it('should return a 400 if you are not a member of an event and trying to update status', function(done) {
+      utils.logIn(function(result, accessToken) {
+        var requestbody = {status: 'much status'};
+        request
+          .put('/events/1/status?accessToken='+accessToken)
+          .send(requestbody)
+          .expect(400, done);
+      }, 0);
+    });
+
   });
 
 });


### PR DESCRIPTION
Fixed #93 

Added 3 new routes: 
- /events/:id/join for users to request to join an event
- /events/:id/approve for hosts to approve/reject pending users from their events
- /events/:id/status for participants of an event to change their status message for an event