### PR TITLE
add makeData for production deployment

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -86,7 +86,10 @@ module.exports = function(grunt) {
     },
     execute: {
       target: {
-        src: ['server/server.js']
+        src: [
+          'TestData/makeData.js',
+          'server/server.js'
+        ]
       }
     },
   });

--- a/TestData/makeData.js
+++ b/TestData/makeData.js
@@ -75,7 +75,7 @@ var createEvents = function() {
   });
 };
 
-//db.sequelize.sync({force: dropTables})
-db.sequelize.sync()
+db.sequelize.sync({force: dropTables})
+//db.sequelize.sync()
   .then(createUsers)
   .then(createEvents);


### PR DESCRIPTION
this drops tables and creates them again prior to seeding users, locations, and events